### PR TITLE
Custom Grain Routing

### DIFF
--- a/Samples/OrleansHttp.Grains/IHelloGrain.cs
+++ b/Samples/OrleansHttp.Grains/IHelloGrain.cs
@@ -12,6 +12,10 @@ namespace OrleansHttp.Grains
         [HttpGet]
         Task<string> Hello([FromQuery]string name);
 
+        // GET grains/Hello?name={name}
+        [HttpGet(pattern: "Hello", routeGrainProvider: typeof(RandomGuidRouteGrainProvider))]
+        Task<string> SimpleHello([FromQuery]string name);
+
         // GET grains/{grainId}/token?admin=[true/false]
         [HttpGet("{grainId}/token")]
         Task<string> GetToken([FromQuery]bool admin);

--- a/Samples/OrleansHttp.Grains/IHelloGrain.cs
+++ b/Samples/OrleansHttp.Grains/IHelloGrain.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
 using Orleans.Http.Abstractions;
@@ -13,7 +13,7 @@ namespace OrleansHttp.Grains
         Task<string> Hello([FromQuery]string name);
 
         // GET grains/Hello?name={name}
-        [HttpGet(pattern: "Hello")]
+        [HttpGet(pattern: "Hello", routeGrainProviderPolicy: nameof(RandomGuidRouteGrainProvider))]
         Task<string> SimpleHello([FromQuery]string name);
 
         // GET grains/{grainId}/token?admin=[true/false]

--- a/Samples/OrleansHttp.Grains/IHelloGrain.cs
+++ b/Samples/OrleansHttp.Grains/IHelloGrain.cs
@@ -13,7 +13,7 @@ namespace OrleansHttp.Grains
         Task<string> Hello([FromQuery]string name);
 
         // GET grains/Hello?name={name}
-        [HttpGet(pattern: "Hello", routeGrainProvider: typeof(RandomGuidRouteGrainProvider))]
+        [HttpGet(pattern: "Hello")]
         Task<string> SimpleHello([FromQuery]string name);
 
         // GET grains/{grainId}/token?admin=[true/false]

--- a/Samples/OrleansHttp.Grains/RandomGuidRouteGrainProvider.cs
+++ b/Samples/OrleansHttp.Grains/RandomGuidRouteGrainProvider.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+using Orleans;
+using Orleans.Http.Abstractions;
+
+namespace OrleansHttp.Grains
+{
+    public class RandomGuidRouteGrainProvider : IRouteGrainProvider
+    {
+        private readonly IClusterClient _cluserClient;
+
+        public RandomGuidRouteGrainProvider(IClusterClient clusterClient)
+        {
+            _cluserClient = clusterClient;
+        }
+
+        public Task<IGrain> GetGrain(Type grainType)
+        {
+            return Task.FromResult(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
+        }
+    }
+}

--- a/Samples/OrleansHttp.Grains/RandomGuidRouteGrainProvider.cs
+++ b/Samples/OrleansHttp.Grains/RandomGuidRouteGrainProvider.cs
@@ -14,9 +14,9 @@ namespace OrleansHttp.Grains
             _cluserClient = clusterClient;
         }
 
-        public Task<IGrain> GetGrain(Type grainType)
+        public ValueTask<IGrain> GetGrain(Type grainType)
         {
-            return Task.FromResult(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
+            return new ValueTask<IGrain>(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
         }
     }
 }

--- a/Samples/OrleansHttp.Host/HelloGrain.cs
+++ b/Samples/OrleansHttp.Host/HelloGrain.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
@@ -25,6 +24,11 @@ namespace OrleansHttp.Host
         public Task<string> Hello(string name)
         {
             return Task.FromResult($"Hello, {name}!");
+        }
+
+        public Task<string> SimpleHello(string name)
+        {
+            return this.Hello(name);
         }
 
         public Task<string> GetToken(bool admin)

--- a/Samples/OrleansHttp.Host/Startup.cs
+++ b/Samples/OrleansHttp.Host/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Orleans.Http;
+using OrleansHttp.Grains;
 
 namespace OrleansHttp.Host
 {
@@ -54,6 +55,10 @@ namespace OrleansHttp.Host
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapGrains("grains");
+            });
+            app.UseRouteGrainProviders(rgppb =>
+            {
+                rgppb.RegisterRouteGrainProvider<RandomGuidRouteGrainProvider>(nameof(RandomGuidRouteGrainProvider));
             });
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -85,9 +85,7 @@ The `Pattern` property of the attributes define the route to be used. If the `Pa
 
 `{optionalPrefix}/{optionalTopLevelPattern}/{grainTypeName}/{grainId}/{methodName}`
 
-If an attribute `Pattern` property is set and the `routeGrainProvider` property is not set, it is required to somewhere into the pattern to add the `{grainId}` string otherwise the route will fail to be registered. Optionally, you can also add `{grainIdExtension}` in case of grains that have Compound keys. 
-
-When the `routeGrainProvider` is set, the type is it set to must implement `IRouteGrainProvider`. The implemented type can utilize dependency injection and must return an IGrain instance that the request will be routed to, or return a null instance. It is recommended to set the response status code to an appropriate response code when returning a null instance, otherwise it will respond with a 500 internal server error.
+By default, if an attribute `Pattern` property is set, it is required to somewhere into the pattern to add the `{grainId}` string otherwise the route will fail to be registered. Optionally, you can also add `{grainIdExtension}` in case of grains that have Compound keys. 
 
 The following attributes are under the `Orleans.Http.Abstractions` package:
 
@@ -105,7 +103,11 @@ When added to a *Grain Method*, this attribute tells the runtime to route ALL HT
 
 This attribute can be applied only to methods.
 
-The value of `Patttern` property is used to generate the route of that method for a particular HTTP Verb. If the patttern starts with `/`, it will ignore all the prefixes and will be used as the de-facto route for that method.
+The value of `Patttern` property is used to generate the route of that method for a particular HTTP Verb. If the patttern starts with `/`, it will ignore all the prefixes and will be used as the de-facto route for that method. 
+
+### `routeGrainProviderPolicy optional argument`
+
+This argument allows you to set the route grain provider used for the speicified endpoint. This allows you to override the default behaviour and provide an `IGrain` that the request will go to. To register a route grain provider policy, use the extension method `UseRouteGrainProviders(Action<IRouteGrainProviderPolcyBuilder>)` on `IApplicationBuilder` In your `Startup` class. The default RouteGrainProvider policy may also be set there. Registering the policy takes in a generic type argument, this type must implement `IRouteGrainProvider`, optionally, if your implementing type is registered with dependency injection, it will use that type's lifetime, otherwise it will have a scoped lifetime by default. 
 
 # Example usage
 
@@ -191,6 +193,15 @@ public class Startup
 
             // You can add any other endpoints here like regular ASP.NET Controller, SignalR, you name it. 
             // Orleans endpoints are agnostic to other routes.
+        });
+
+        //Optionally register route grain provider policies
+        app.UseRouteGrainProviders(routeGrainProviders =>
+        {
+            routeGrainProviders.RegisterRouteGrainProvider<YourCustomRouteGrainProvider>("SomePolicy");
+
+            //You may also optionally set the defaulty policy, so it it used by every endpoint without a specified policy
+            routeGrainProviders.SetDefaultRouteGrainProviderPolicy("SomePolicy");
         });
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,9 @@ The `Pattern` property of the attributes define the route to be used. If the `Pa
 
 `{optionalPrefix}/{optionalTopLevelPattern}/{grainTypeName}/{grainId}/{methodName}`
 
-If an attribute `Pattern` property is set, it is required to somewhere into the pattern to add the `{grainId}` string otherwise the route will fail to be registered. Optionally, you can also add `{grainIdExtension}` in case of grains that have Compound keys.
+If an attribute `Pattern` property is set and the `routeGrainProvider` property is not set, it is required to somewhere into the pattern to add the `{grainId}` string otherwise the route will fail to be registered. Optionally, you can also add `{grainIdExtension}` in case of grains that have Compound keys. 
+
+When the `routeGrainProvider` is set, the type is it set to must implement `IRouteGrainProvider`. The implemented type can utilize dependency injection and must return an IGrain instance that the request will be routed to, or return a null instance. It is recommended to set the response status code to an appropriate response code when returning a null instance, otherwise it will respond with a 500 internal server error.
 
 The following attributes are under the `Orleans.Http.Abstractions` package:
 

--- a/src/Orleans.Http.Abstractions/Attributes.cs
+++ b/src/Orleans.Http.Abstractions/Attributes.cs
@@ -6,55 +6,55 @@ namespace Orleans.Http.Abstractions
     {
         public string Pattern { get; private set; }
         public string Name { get; private set; }
-        public Type RouteGrainProvider { get; private set; }
+        public string RouteGrainProviderPolicy { get; private set; }
 
-        protected GrainRouteAttributeBase(string pattern = "", string name = "", Type routeGrainProvider = null)
+        protected GrainRouteAttributeBase(string pattern = "", string name = "", string routeGrainProviderPolicy = "")
         {
             this.Pattern = pattern;
             this.Name = name;
-            this.RouteGrainProvider = routeGrainProvider;
+            this.RouteGrainProviderPolicy = routeGrainProviderPolicy;
         }
     }
 
     [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method, AllowMultiple = true)]
     public class RouteAttribute : GrainRouteAttributeBase
     {
-        public RouteAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+        public RouteAttribute(string pattern = "", string name = "", string routeGrainProviderPolicy = "") : base(pattern, name, routeGrainProviderPolicy) { }
     }
 
     public abstract class MethodAttribute : GrainRouteAttributeBase
     {
         public abstract string Method { get; }
 
-        protected MethodAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+        protected MethodAttribute(string pattern = "", string name = "", string routeGrainProviderPolicy = "") : base(pattern, name, routeGrainProviderPolicy) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpGetAttribute : MethodAttribute
     {
         public override string Method { get => "GET"; }
-        public HttpGetAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+        public HttpGetAttribute(string pattern = "", string name = "", string routeGrainProviderPolicy = "") : base(pattern, name, routeGrainProviderPolicy) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpPostAttribute : MethodAttribute
     {
         public override string Method { get => "POST"; }
-        public HttpPostAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+        public HttpPostAttribute(string pattern = "", string name = "", string routeGrainProviderPolicy = "") : base(pattern, name, routeGrainProviderPolicy) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpPutAttribute : MethodAttribute
     {
         public override string Method { get => "PUT"; }
-        public HttpPutAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+        public HttpPutAttribute(string pattern = "", string name = "", string routeGrainProviderPolicy = "") : base(pattern, name, routeGrainProviderPolicy) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpDeleteAttribute : MethodAttribute
     {
         public override string Method { get => "DELETE"; }
-        public HttpDeleteAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+        public HttpDeleteAttribute(string pattern = "", string name = "", string routeGrainProviderPolicy = "") : base(pattern, name, routeGrainProviderPolicy) { }
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]

--- a/src/Orleans.Http.Abstractions/Attributes.cs
+++ b/src/Orleans.Http.Abstractions/Attributes.cs
@@ -2,58 +2,59 @@ using System;
 
 namespace Orleans.Http.Abstractions
 {
-    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method, AllowMultiple = true)]
-    public class RouteAttribute : Attribute
+    public abstract class GrainRouteAttributeBase : Attribute
     {
         public string Pattern { get; private set; }
         public string Name { get; private set; }
+        public Type RouteGrainProvider { get; private set; }
 
-        public RouteAttribute(string pattern = "", string name = "")
+        protected GrainRouteAttributeBase(string pattern = "", string name = "", Type routeGrainProvider = null)
         {
             this.Pattern = pattern;
             this.Name = name;
+            this.RouteGrainProvider = routeGrainProvider;
         }
     }
 
-    public abstract class MethodAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method, AllowMultiple = true)]
+    public class RouteAttribute : GrainRouteAttributeBase
+    {
+        public RouteAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
+    }
+
+    public abstract class MethodAttribute : GrainRouteAttributeBase
     {
         public abstract string Method { get; }
-        public string Pattern { get; private set; }
-        public string Name { get; private set; }
 
-        public MethodAttribute(string pattern = "", string name = "")
-        {
-            this.Pattern = pattern;
-            this.Name = name;
-        }
+        protected MethodAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpGetAttribute : MethodAttribute
     {
         public override string Method { get => "GET"; }
-        public HttpGetAttribute(string pattern = "", string name = "") : base(pattern, name) { }
+        public HttpGetAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpPostAttribute : MethodAttribute
     {
         public override string Method { get => "POST"; }
-        public HttpPostAttribute(string pattern = "", string name = "") : base(pattern, name) { }
+        public HttpPostAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpPutAttribute : MethodAttribute
     {
         public override string Method { get => "PUT"; }
-        public HttpPutAttribute(string pattern = "", string name = "") : base(pattern, name) { }
+        public HttpPutAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
     }
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class HttpDeleteAttribute : MethodAttribute
     {
         public override string Method { get => "DELETE"; }
-        public HttpDeleteAttribute(string pattern = "", string name = "") : base(pattern, name) { }
+        public HttpDeleteAttribute(string pattern = "", string name = "", Type routeGrainProvider = null) : base(pattern, name, routeGrainProvider) { }
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]

--- a/src/Orleans.Http.Abstractions/IRouteGrainProvider.cs
+++ b/src/Orleans.Http.Abstractions/IRouteGrainProvider.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Http.Abstractions
+{
+    public interface IRouteGrainProvider
+    {
+        Task<IGrain> GetGrain(Type grainType);
+    }
+}

--- a/src/Orleans.Http.Abstractions/IRouteGrainProvider.cs
+++ b/src/Orleans.Http.Abstractions/IRouteGrainProvider.cs
@@ -5,6 +5,6 @@ namespace Orleans.Http.Abstractions
 {
     public interface IRouteGrainProvider
     {
-        Task<IGrain> GetGrain(Type grainType);
+        ValueTask<IGrain> GetGrain(Type grainType);
     }
 }

--- a/src/Orleans.Http.Abstractions/IRouteGrainProviderPolicyBuilder.cs
+++ b/src/Orleans.Http.Abstractions/IRouteGrainProviderPolicyBuilder.cs
@@ -1,0 +1,8 @@
+namespace Orleans.Http.Abstractions
+{
+    public interface IRouteGrainProviderPolicyBuilder
+    {
+        IRouteGrainProviderPolicyBuilder RegisterRouteGrainProvider<T>(string policyName) where T : IRouteGrainProvider;
+        IRouteGrainProviderPolicyBuilder SetDefaultRouteGrainProviderPolicy(string policyName);
+    }
+}

--- a/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
+++ b/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Orleans.Http.Abstractions;
+
+namespace Orleans.Http
+{
+    public class GrainIdFromRouteGrainProvider : IRouteGrainProvider
+    {
+        private enum GrainIdType
+        {
+            Guid = 0,
+            String = 1,
+            Integer = 2,
+            GuidCompound = 3,
+            IntegerCompound = 4
+        }
+
+        private readonly IClusterClient _clusterClient;
+        private readonly ILogger _logger;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public GrainIdFromRouteGrainProvider(IClusterClient clusterClient, ILoggerFactory loggerFactory, IHttpContextAccessor httpContextAccessor)
+        {
+            _clusterClient = clusterClient;
+            _logger = loggerFactory.CreateLogger<GrainIdFromRouteGrainProvider>();
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public Task<IGrain> GetGrain(Type grainType)
+        {
+            var context = this._httpContextAccessor.HttpContext;
+            var endpoint = (RouteEndpoint)context.GetEndpoint();
+            var pattern = endpoint.RoutePattern;
+
+            try
+            {
+                var grainIdType = this.GetGrainIdType(grainType);
+                var grainIdParameter = context.Request.RouteValues[Constants.GRAIN_ID];
+                var grainIdExtensionParameter = context.Request.RouteValues.ContainsKey(Constants.GRAIN_ID_EXTENSION) ? context.Request.RouteValues[Constants.GRAIN_ID] : null;
+                switch (grainIdType)
+                {
+                    case GrainIdType.String:
+                        string stringId = (string)grainIdParameter;
+                        return Task.FromResult(this._clusterClient.GetGrain(grainType, stringId));
+                    case GrainIdType.Integer:
+                        long integerId = Convert.ToInt64(grainIdParameter);
+                        return Task.FromResult(this._clusterClient.GetGrain(grainType, integerId));
+                    case GrainIdType.IntegerCompound:
+                        return Task.FromResult(this._clusterClient.GetGrain(grainType, Convert.ToInt64(grainIdParameter), (string)grainIdExtensionParameter));
+                    case GrainIdType.GuidCompound:
+                        return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter), (string)grainIdExtensionParameter));
+                    default:
+                        return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter)));
+                }
+            }
+            catch (Exception exc)
+            {
+                this._logger.LogError(exc, $"Failure getting grain '{grainType.FullName}' for route '{pattern.RawText}': {exc.Message}");
+                return null;
+            }
+        }
+
+        private GrainIdType GetGrainIdType(Type grainInterfaceType)
+        {
+            var ifaces = grainInterfaceType.GetInterfaces();
+            if (ifaces.Contains(typeof(IGrainWithGuidKey)))
+            {
+                return GrainIdType.Guid;
+            }
+            else if (ifaces.Contains(typeof(IGrainWithGuidCompoundKey)))
+            {
+                return GrainIdType.GuidCompound;
+            }
+            else if (ifaces.Contains(typeof(IGrainWithIntegerKey)))
+            {
+                return GrainIdType.Integer;
+            }
+            else if (ifaces.Contains(typeof(IGrainWithIntegerCompoundKey)))
+            {
+                return GrainIdType.IntegerCompound;
+            }
+            else
+            {
+                return GrainIdType.String;
+            }
+        }
+    }
+}

--- a/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
+++ b/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
@@ -19,6 +19,8 @@ namespace Orleans.Http
             IntegerCompound = 4
         }
 
+        private static readonly ValueTask<IGrain> _nullGrainReference = default;
+
         private readonly IClusterClient _clusterClient;
         private readonly ILogger _logger;
         private readonly IHttpContextAccessor _httpContextAccessor;
@@ -61,15 +63,13 @@ namespace Orleans.Http
                 }
 
                 context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
-                IGrain nullResult = null;
-                return new ValueTask<IGrain>(nullResult);
+                return _nullGrainReference;
             }
             catch (Exception exc)
             {
                 context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
                 this._logger.LogError(exc, $"Failure getting grain '{grainType.FullName}' for route '{pattern.RawText}': {exc.Message}");
-                IGrain nullResult = null;
-                return new ValueTask<IGrain>(nullResult);
+                return _nullGrainReference;
             }
         }
 

--- a/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
+++ b/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
@@ -30,7 +30,7 @@ namespace Orleans.Http
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public Task<IGrain> GetGrain(Type grainType)
+        public ValueTask<IGrain> GetGrain(Type grainType)
         {
             var context = this._httpContextAccessor.HttpContext;
             var endpoint = (RouteEndpoint)context.GetEndpoint();
@@ -47,27 +47,29 @@ namespace Orleans.Http
                     {
                         case GrainIdType.String:
                             string stringId = (string)grainIdParameter;
-                            return Task.FromResult(this._clusterClient.GetGrain(grainType, stringId));
+                            return new ValueTask<IGrain>(this._clusterClient.GetGrain(grainType, stringId));
                         case GrainIdType.Integer:
                             long integerId = Convert.ToInt64(grainIdParameter);
-                            return Task.FromResult(this._clusterClient.GetGrain(grainType, integerId));
+                            return new ValueTask<IGrain>(this._clusterClient.GetGrain(grainType, integerId));
                         case GrainIdType.IntegerCompound:
-                            return Task.FromResult(this._clusterClient.GetGrain(grainType, Convert.ToInt64(grainIdParameter), (string)grainIdExtensionParameter));
+                            return new ValueTask<IGrain>(this._clusterClient.GetGrain(grainType, Convert.ToInt64(grainIdParameter), (string)grainIdExtensionParameter));
                         case GrainIdType.GuidCompound:
-                            return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter), (string)grainIdExtensionParameter));
+                            return new ValueTask<IGrain>(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter), (string)grainIdExtensionParameter));
                         default:
-                            return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter)));
+                            return new ValueTask<IGrain>(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter)));
                     }
                 }
 
                 context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
-                return Task.FromResult<IGrain>(null);
+                IGrain nullResult = null;
+                return new ValueTask<IGrain>(nullResult);
             }
             catch (Exception exc)
             {
                 context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
                 this._logger.LogError(exc, $"Failure getting grain '{grainType.FullName}' for route '{pattern.RawText}': {exc.Message}");
-                return Task.FromResult<IGrain>(null);
+                IGrain nullResult = null;
+                return new ValueTask<IGrain>(nullResult);
             }
         }
 

--- a/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
+++ b/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
@@ -61,12 +61,13 @@ namespace Orleans.Http
                 }
 
                 context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
-                return null;
+                return Task.FromResult<IGrain>(null);
             }
             catch (Exception exc)
             {
+                context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
                 this._logger.LogError(exc, $"Failure getting grain '{grainType.FullName}' for route '{pattern.RawText}': {exc.Message}");
-                return null;
+                return Task.FromResult<IGrain>(null);
             }
         }
 

--- a/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
+++ b/src/Orleans.Http/GrainIdFromRouteGrainProvider.cs
@@ -38,24 +38,30 @@ namespace Orleans.Http
 
             try
             {
-                var grainIdType = this.GetGrainIdType(grainType);
-                var grainIdParameter = context.Request.RouteValues[Constants.GRAIN_ID];
-                var grainIdExtensionParameter = context.Request.RouteValues.ContainsKey(Constants.GRAIN_ID_EXTENSION) ? context.Request.RouteValues[Constants.GRAIN_ID] : null;
-                switch (grainIdType)
+                if (context.Request.RouteValues.ContainsKey(Constants.GRAIN_ID))
                 {
-                    case GrainIdType.String:
-                        string stringId = (string)grainIdParameter;
-                        return Task.FromResult(this._clusterClient.GetGrain(grainType, stringId));
-                    case GrainIdType.Integer:
-                        long integerId = Convert.ToInt64(grainIdParameter);
-                        return Task.FromResult(this._clusterClient.GetGrain(grainType, integerId));
-                    case GrainIdType.IntegerCompound:
-                        return Task.FromResult(this._clusterClient.GetGrain(grainType, Convert.ToInt64(grainIdParameter), (string)grainIdExtensionParameter));
-                    case GrainIdType.GuidCompound:
-                        return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter), (string)grainIdExtensionParameter));
-                    default:
-                        return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter)));
+                    var grainIdType = this.GetGrainIdType(grainType);
+                    var grainIdParameter = context.Request.RouteValues[Constants.GRAIN_ID];
+                    var grainIdExtensionParameter = context.Request.RouteValues.ContainsKey(Constants.GRAIN_ID_EXTENSION) ? context.Request.RouteValues[Constants.GRAIN_ID] : null;
+                    switch (grainIdType)
+                    {
+                        case GrainIdType.String:
+                            string stringId = (string)grainIdParameter;
+                            return Task.FromResult(this._clusterClient.GetGrain(grainType, stringId));
+                        case GrainIdType.Integer:
+                            long integerId = Convert.ToInt64(grainIdParameter);
+                            return Task.FromResult(this._clusterClient.GetGrain(grainType, integerId));
+                        case GrainIdType.IntegerCompound:
+                            return Task.FromResult(this._clusterClient.GetGrain(grainType, Convert.ToInt64(grainIdParameter), (string)grainIdExtensionParameter));
+                        case GrainIdType.GuidCompound:
+                            return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter), (string)grainIdExtensionParameter));
+                        default:
+                            return Task.FromResult(this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter)));
+                    }
                 }
+
+                context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
+                return null;
             }
             catch (Exception exc)
             {

--- a/src/Orleans.Http/GrainInvoker.cs
+++ b/src/Orleans.Http/GrainInvoker.cs
@@ -37,7 +37,7 @@ namespace Orleans.Http
 
             if (routeGrainProviderType != null)
             {
-                if(routeGrainProviderType.IsAssignableFrom(typeof(IRouteGrainProvider)))
+                if(typeof(IRouteGrainProvider).IsAssignableFrom(routeGrainProviderType))
                 {
                     this.RouteGrainProvider = (IRouteGrainProvider)ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, routeGrainProviderType);
                 }

--- a/src/Orleans.Http/GrainInvoker.cs
+++ b/src/Orleans.Http/GrainInvoker.cs
@@ -37,7 +37,14 @@ namespace Orleans.Http
 
             if (routeGrainProviderType != null)
             {
-                this.RouteGrainProvider = (IRouteGrainProvider)ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, routeGrainProviderType);
+                if(routeGrainProviderType.IsAssignableFrom(typeof(IRouteGrainProvider)))
+                {
+                    this.RouteGrainProvider = (IRouteGrainProvider)ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, routeGrainProviderType);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Can not use type {routeGrainProviderType} as RouteGrainProvider, it must implement Orleans.Http.Abstractions.IRouteGrainProvider. Found on {methodInfo.DeclaringType}.{methodInfo.Name}");
+                }
             }
             else
             {

--- a/src/Orleans.Http/GrainInvoker.cs
+++ b/src/Orleans.Http/GrainInvoker.cs
@@ -29,38 +29,26 @@ namespace Orleans.Http
         private bool _isIGrainHttpResultType;
         public Type GrainType => this._methodInfo.DeclaringType;
 
-        private Type _routeGrainProviderType = null;
+        private string _routeGrainProviderPolicy;
         public IRouteGrainProvider RouteGrainProvider
         {
             get
             {
-                if(this._routeGrainProviderType == null)
+                if(string.IsNullOrEmpty(this._routeGrainProviderPolicy))
                 {
                     return this._routeGrainProviderFactory.CreateDefault();
                 }
-                return this._routeGrainProviderFactory.Create(this._routeGrainProviderType);
+                return this._routeGrainProviderFactory.Create(this._routeGrainProviderPolicy);
             }
         }
 
-        public GrainInvoker(IServiceProvider serviceProvider, MethodInfo methodInfo, Type routeGrainProviderType)
+        public GrainInvoker(IServiceProvider serviceProvider, MethodInfo methodInfo, string routeGrainProviderPolicy)
         {
             this._logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<GrainInvoker>();
             this._methodInfo = methodInfo;
             this._mediaTypeManager = serviceProvider.GetRequiredService<MediaTypeManager>();
             this._routeGrainProviderFactory = serviceProvider.GetRequiredService<RouteGrainProviderFactory>();
-            this._routeGrainProviderType = routeGrainProviderType;
-
-            if (routeGrainProviderType != null)
-            {
-                if(typeof(IRouteGrainProvider).IsAssignableFrom(routeGrainProviderType))
-                {
-                    this._routeGrainProviderType = routeGrainProviderType;
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Can not use type {routeGrainProviderType} as RouteGrainProvider, it must implement Orleans.Http.Abstractions.IRouteGrainProvider. Found on {methodInfo.DeclaringType}.{methodInfo.Name}");
-                }
-            }
+            this._routeGrainProviderPolicy = routeGrainProviderPolicy;
 
             this.BuildResultDelegate();
             this.BuildParameterMap();

--- a/src/Orleans.Http/GrainRouter.cs
+++ b/src/Orleans.Http/GrainRouter.cs
@@ -52,7 +52,15 @@ namespace Orleans.Http
                 invoker = allRoutes[context.Request.Method];
             }
 
-            IGrain grain = await invoker.RouteGrainProvider.GetGrain(invoker.GrainType);
+            IGrain grain = null;
+            try
+            {
+                grain = await invoker.RouteGrainProvider.GetGrain(invoker.GrainType);
+            }
+            catch(Exception ex)
+            {
+                this._logger.LogError(ex, "");
+            }
 
             if (grain == null)
             {

--- a/src/Orleans.Http/GrainRouter.cs
+++ b/src/Orleans.Http/GrainRouter.cs
@@ -1,51 +1,42 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Orleans.Http
 {
     internal class GrainRouter
     {
-        private IServiceProvider _serviceProvider;
-        private readonly IClusterClient _clusterClient;
-        private readonly ILogger _logger;
+        private readonly IServiceProvider _serviceProvider;
         private readonly Dictionary<string, Dictionary<string, GrainInvoker>> _routes = new Dictionary<string, Dictionary<string, GrainInvoker>>(StringComparer.InvariantCultureIgnoreCase);
 
-        public GrainRouter(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
+        public GrainRouter(IServiceProvider serviceProvider)
         {
             this._serviceProvider = serviceProvider;
-            this._clusterClient = serviceProvider.GetRequiredService<IClusterClient>();
-            this._logger = loggerFactory.CreateLogger<GrainRouter>();
         }
 
-        public bool RegisterRoute(string pattern, string httpMethod, MethodInfo method)
+        public bool RegisterRoute(string pattern, string httpMethod, MethodInfo method, Type routeGrainProviderType)
         {
-            var grainInterfaceType = method.DeclaringType;
-            var grainIdType = this.GetGrainIdType(grainInterfaceType);
-
             if (this._routes.TryGetValue(pattern, out var grainRoutes))
             {
                 if (grainRoutes.ContainsKey(httpMethod)) return false;
 
-                grainRoutes[httpMethod] = new GrainInvoker(this._serviceProvider, grainIdType, method);
+                grainRoutes[httpMethod] = new GrainInvoker(this._serviceProvider, method, routeGrainProviderType);
             }
             else
             {
-                this._routes[pattern] = new Dictionary<string, GrainInvoker>(StringComparer.InvariantCultureIgnoreCase);
-                this._routes[pattern][httpMethod] = new GrainInvoker(this._serviceProvider, grainIdType, method);
+                this._routes[pattern] = new Dictionary<string, GrainInvoker>(StringComparer.InvariantCultureIgnoreCase)
+                {
+                    [httpMethod] = new GrainInvoker(this._serviceProvider, method, routeGrainProviderType)
+                };
             }
 
             return true;
         }
 
-        public Task Dispatch(HttpContext context)
+        public async Task Dispatch(HttpContext context)
         {
             var endpoint = (RouteEndpoint)context.GetEndpoint();
             var pattern = endpoint.RoutePattern;
@@ -58,79 +49,16 @@ namespace Orleans.Http
                 invoker = allRoutes[context.Request.Method];
             }
 
-            IGrain grain = this.GetGrain(pattern, invoker.GrainType, invoker.GrainIdType, context);
+            IGrain grain = await invoker.RouteGrainProvider.GetGrain(invoker.GrainType);
 
             if (grain == null)
             {
                 // We only faw here if the grainId is mal formed
-                context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
-                return Task.CompletedTask;
+                //context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
+                return;
             }
 
-            return invoker.Invoke(grain, context);
+            await invoker.Invoke(grain, context);
         }
-
-        private IGrain GetGrain(RoutePattern pattern, Type grainType, GrainIdType grainIdType, HttpContext context)
-        {
-            try
-            {
-                var grainIdParameter = context.Request.RouteValues[Constants.GRAIN_ID];
-                var grainIdExtensionParameter = context.Request.RouteValues.ContainsKey(Constants.GRAIN_ID_EXTENSION) ? context.Request.RouteValues[Constants.GRAIN_ID] : null;
-                switch (grainIdType)
-                {
-                    case GrainIdType.String:
-                        string stringId = (string)grainIdParameter;
-                        return this._clusterClient.GetGrain(grainType, stringId);
-                    case GrainIdType.Integer:
-                        long integerId = Convert.ToInt64(grainIdParameter);
-                        return this._clusterClient.GetGrain(grainType, integerId);
-                    case GrainIdType.IntegerCompound:
-                        return this._clusterClient.GetGrain(grainType, Convert.ToInt64(grainIdParameter), (string)grainIdExtensionParameter);
-                    case GrainIdType.GuidCompound:
-                        return this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter), (string)grainIdExtensionParameter);
-                    default:
-                        return this._clusterClient.GetGrain(grainType, Guid.Parse((string)grainIdParameter));
-                }
-            }
-            catch (Exception exc)
-            {
-                this._logger.LogError(exc, $"Failure getting grain '{grainType.FullName} | {grainIdType}' for route '{pattern.RawText}': {exc.Message}");
-                return null;
-            }
-        }
-
-        private GrainIdType GetGrainIdType(Type grainInterfaceType)
-        {
-            var ifaces = grainInterfaceType.GetInterfaces();
-            if (ifaces.Contains(typeof(IGrainWithGuidKey)))
-            {
-                return GrainIdType.Guid;
-            }
-            else if (ifaces.Contains(typeof(IGrainWithGuidCompoundKey)))
-            {
-                return GrainIdType.GuidCompound;
-            }
-            else if (ifaces.Contains(typeof(IGrainWithIntegerKey)))
-            {
-                return GrainIdType.Integer;
-            }
-            else if (ifaces.Contains(typeof(IGrainWithIntegerCompoundKey)))
-            {
-                return GrainIdType.IntegerCompound;
-            }
-            else
-            {
-                return GrainIdType.String;
-            }
-        }
-    }
-
-    internal enum GrainIdType
-    {
-        Guid = 0,
-        String = 1,
-        Integer = 2,
-        GuidCompound = 3,
-        IntegerCompound = 4
     }
 }

--- a/src/Orleans.Http/HostingExtensions.cs
+++ b/src/Orleans.Http/HostingExtensions.cs
@@ -31,7 +31,8 @@ namespace Orleans.Http
         {
             return services
                 .AddSingleton<MediaTypeManager>()
-                .AddSingleton<GrainRouter>();
+                .AddSingleton<GrainRouter>()
+                .AddSingleton<RouteGrainProviderFactory>();
         }
 
         public static IServiceCollection AddJsonMediaType(this IServiceCollection services, Action<JsonSerializerOptions> configure = null)
@@ -61,6 +62,20 @@ namespace Orleans.Http
         {
             return services
                 .AddSingleton<IMediaTypeHandler, FormsMediaTypeHandler>();
+        }
+
+        public static IEndpointRouteBuilder SetDefaultRouteGrainProvider<T>(this IEndpointRouteBuilder routes) where T : IRouteGrainProvider
+        {
+            return routes.SetDefaultRouteGrainProvider(typeof(T));
+        }
+
+        public static IEndpointRouteBuilder SetDefaultRouteGrainProvider(this IEndpointRouteBuilder routes, Type routeGrainProviderType)
+        {
+            var routeGrainProviderFactory = routes.ServiceProvider.GetRequiredService<RouteGrainProviderFactory>();
+
+            routeGrainProviderFactory.SetDefaultRouteGrainProvider(routeGrainProviderType);
+
+            return routes;
         }
 
         public static IEndpointRouteBuilder MapGrains(this IEndpointRouteBuilder routes, string prefix = "")

--- a/src/Orleans.Http/HostingExtensions.cs
+++ b/src/Orleans.Http/HostingExtensions.cs
@@ -136,16 +136,19 @@ namespace Orleans.Http
                     Func<RoutePattern, RequestDelegate, IEndpointConventionBuilder> mapFunc = default;
                     var httpMethod = string.Empty;
                     RoutePattern routePattern = default;
+                    Type routeGrainProviderType = null;
 
                     if (attribute is RouteAttribute routeAttr)
                     {
                         routePattern = RoutePatternBuilder.BuildRoutePattern(prefix, topLevelPattern, grainType.FullName, method.Name, routeAttr.Pattern);
+                        routeGrainProviderType = routeAttr.RouteGrainProvider;
                         httpMethod = "*";
                         mapFunc = routes.Map;
                     }
                     else if (attribute is MethodAttribute methodAttr)
                     {
                         routePattern = RoutePatternBuilder.BuildRoutePattern(prefix, topLevelPattern, grainType.FullName, method.Name, methodAttr.Pattern);
+                        routeGrainProviderType = methodAttr.RouteGrainProvider;
 
                         Func<string, RequestDelegate, IEndpointConventionBuilder> methodMapFunc = default;
 
@@ -178,7 +181,7 @@ namespace Orleans.Http
                         continue;
                     }
 
-                    if (!dispatcher.RegisterRoute(routePattern.RawText, httpMethod, method))
+                    if (!dispatcher.RegisterRoute(routePattern.RawText, httpMethod, method, routeGrainProviderType))
                     {
                         throw new InvalidOperationException($"Dupplicated route pattern '{routePattern.RawText}'. A route with this pattern already exist.");
                     }

--- a/src/Orleans.Http/RouteGrainProviderFactory.cs
+++ b/src/Orleans.Http/RouteGrainProviderFactory.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Http.Abstractions;
+
+namespace Orleans.Http
+{
+    internal sealed class RouteGrainProviderFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        private Type _defaultRouteGrainProvider = typeof(GrainIdFromRouteGrainProvider);
+
+        public RouteGrainProviderFactory(IServiceProvider serviceProvider)
+        {
+            this._serviceProvider = serviceProvider;
+        }
+
+        public IRouteGrainProvider Create(Type routeGrainProviderType)
+        {
+            if (typeof(IRouteGrainProvider).IsAssignableFrom(routeGrainProviderType))
+            {
+                return (IRouteGrainProvider)ActivatorUtilities.GetServiceOrCreateInstance(this._serviceProvider, routeGrainProviderType);
+            }
+
+            throw new InvalidOperationException($"Can not use type {routeGrainProviderType} as RouteGrainProvider, it must implement Orleans.Http.Abstractions.IRouteGrainProvider");
+        }
+
+        public IRouteGrainProvider CreateDefault()
+        {
+            return (IRouteGrainProvider)ActivatorUtilities.GetServiceOrCreateInstance(this._serviceProvider, this._defaultRouteGrainProvider);
+        }
+
+        public void SetDefaultRouteGrainProvider(Type routeGrainProviderType)
+        {
+            if (typeof(IRouteGrainProvider).IsAssignableFrom(routeGrainProviderType))
+            {
+                this._defaultRouteGrainProvider = routeGrainProviderType;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Can not use type {routeGrainProviderType} as RouteGrainProvider, it must implement Orleans.Http.Abstractions.IRouteGrainProvider");
+            }
+        }
+    }
+}

--- a/src/Orleans.Http/RoutePatternBuilder.cs
+++ b/src/Orleans.Http/RoutePatternBuilder.cs
@@ -34,8 +34,8 @@ namespace Orleans.Http
 
         private static bool ValidatePattern(string pattern)
         {
-            // When more elaborated routes are supported, we will have more rules here
-            return pattern.Contains(GRAIN_ID_TOKEN);
+            // No rules to currently enforce
+            return true;
         }
     }
 }

--- a/src/Orleans.Http/RoutePatternBuilder.cs
+++ b/src/Orleans.Http/RoutePatternBuilder.cs
@@ -16,8 +16,6 @@ namespace Orleans.Http
             // If the user defined a pattern then lets use it
             if (!string.IsNullOrWhiteSpace(routeAttributePattern))
             {
-                if (!ValidatePattern(routeAttributePattern)) return null;
-
                 if (routeAttributePattern.StartsWith("/"))
                 {
                     return RoutePatternFactory.Parse(routeAttributePattern);
@@ -30,12 +28,6 @@ namespace Orleans.Http
 
             // Otherwise lets use the default one
             return RoutePatternFactory.Parse($"{prefix}{topLevelPattern}{grainTypeName}/{{grainId}}/{methodName}");
-        }
-
-        private static bool ValidatePattern(string pattern)
-        {
-            // No rules to currently enforce
-            return true;
         }
     }
 }

--- a/test/Orleans.Http.Test/HostFixture.cs
+++ b/test/Orleans.Http.Test/HostFixture.cs
@@ -18,7 +18,13 @@ namespace Orleans.Http.Test
     {
         public IHost Host { get; private set; }
         public HttpClient Http { get; private set; }
+
         public HostFixture()
+        {
+            this.Run();
+        }
+
+        public void Run()
         {
             var hostBuilder = new HostBuilder();
             hostBuilder.UseConsoleLifetime();
@@ -38,9 +44,12 @@ namespace Orleans.Http.Test
 
             this.Host = hostBuilder.Build();
             this.Host.Start();
-            this.Http = new HttpClient();
-            this.Http.BaseAddress = new Uri("http://localhost:9090");
+            this.Http = new HttpClient
+            {
+                BaseAddress = new Uri("http://localhost:9090")
+            };
         }
+
         public void Dispose()
         {
             this.Host.StopAsync().Wait();

--- a/test/Orleans.Http.Test/HttpTests.cs
+++ b/test/Orleans.Http.Test/HttpTests.cs
@@ -89,9 +89,13 @@ namespace Orleans.Http.Test
             response = await this._http.PostAsync(url, new StringContent(""));
             Assert.True(response.StatusCode == HttpStatusCode.OK);
 
-            url = "/grains/test/get";
+            url = "/grains/test/get6";
             response = await this._http.GetHttpMessage(TestExtensions.JSON, url);
             Assert.True(response.StatusCode == HttpStatusCode.OK);
+
+            url = "/grains/test/get7";
+            response = await this._http.GetHttpMessage(TestExtensions.JSON, url);
+            Assert.True(response.StatusCode == HttpStatusCode.InternalServerError);
         }
 
         [Fact]

--- a/test/Orleans.Http.Test/HttpTests.cs
+++ b/test/Orleans.Http.Test/HttpTests.cs
@@ -88,6 +88,10 @@ namespace Orleans.Http.Test
             url = "/grains/test/00000000-0000-0000-0000-000000000000/SameUrlAndMethod";
             response = await this._http.PostAsync(url, new StringContent(""));
             Assert.True(response.StatusCode == HttpStatusCode.OK);
+
+            url = "/grains/test/get";
+            response = await this._http.GetHttpMessage(TestExtensions.JSON, url);
+            Assert.True(response.StatusCode == HttpStatusCode.OK);
         }
 
         [Fact]

--- a/test/Orleans.Http.Test/HttpTests.cs
+++ b/test/Orleans.Http.Test/HttpTests.cs
@@ -96,6 +96,10 @@ namespace Orleans.Http.Test
             url = "/grains/test/get7";
             response = await this._http.GetHttpMessage(TestExtensions.JSON, url);
             Assert.True(response.StatusCode == HttpStatusCode.InternalServerError);
+
+            url = "/grains/test/Orleans.Http.Test.ITestGrain/malformed-grain-id/get";
+            response = await this._http.GetHttpMessage(TestExtensions.JSON, url);
+            Assert.True(response.StatusCode == HttpStatusCode.BadRequest);
         }
 
         [Fact]

--- a/test/Orleans.Http.Test/Startup.cs
+++ b/test/Orleans.Http.Test/Startup.cs
@@ -57,9 +57,15 @@ namespace Orleans.Http.Test
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapGrains("grains");
-                if(UseRandomGuidDefaultGrainProvider)
+            });
+            app.UseRouteGrainProviders(rgppb =>
+            {
+                rgppb.RegisterRouteGrainProvider<RandomGuidRouteGrainProvider>(nameof(RandomGuidRouteGrainProvider));
+                rgppb.RegisterRouteGrainProvider<FailingRouteGrainProvider>(nameof(FailingRouteGrainProvider));
+
+                if (UseRandomGuidDefaultGrainProvider)
                 {
-                    endpoints.SetDefaultRouteGrainProvider<RandomGuidRouteGrainProvider>();
+                    rgppb.SetDefaultRouteGrainProviderPolicy(nameof(RandomGuidRouteGrainProvider));
                 }
             });
         }

--- a/test/Orleans.Http.Test/Startup.cs
+++ b/test/Orleans.Http.Test/Startup.cs
@@ -11,7 +11,11 @@ namespace Orleans.Http.Test
 {
     public class Startup
     {
+        //Test Options
+        public static bool UseRandomGuidDefaultGrainProvider { get; set; }
+
         public const string SECRET = "THIS IS OUR AWESOME SUPER SECRET!!!";
+
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
@@ -53,6 +57,10 @@ namespace Orleans.Http.Test
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapGrains("grains");
+                if(UseRandomGuidDefaultGrainProvider)
+                {
+                    endpoints.SetDefaultRouteGrainProvider<RandomGuidRouteGrainProvider>();
+                }
             });
         }
     }

--- a/test/Orleans.Http.Test/TestGrain.cs
+++ b/test/Orleans.Http.Test/TestGrain.cs
@@ -70,6 +70,9 @@ namespace Orleans.Http.Test
         [HttpGet("{grainId}/SameUrlAndMethod")]
         [HttpPost("{grainId}/SameUrlAndMethod")]
         Task SameUrlAndMethod();
+
+        [HttpGet(pattern: "Get", routeGrainProvider: typeof(RandomGuidRouteGrainProvider))]
+        Task Get5();
     }
 
     [ProtoContract]
@@ -171,5 +174,22 @@ namespace Orleans.Http.Test
         public Task SameUrlPost() => Task.CompletedTask;
 
         public Task SameUrlAndMethod() => Task.CompletedTask;
+
+        public Task Get5() => Task.CompletedTask;
+    }
+
+    public class RandomGuidRouteGrainProvider : IRouteGrainProvider
+    {
+        private readonly IClusterClient _cluserClient;
+
+        public RandomGuidRouteGrainProvider(IClusterClient clusterClient)
+        {
+            _cluserClient = clusterClient;
+        }
+
+        public Task<IGrain> GetGrain(Type grainType)
+        {
+            return Task.FromResult(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
+        }
     }
 }

--- a/test/Orleans.Http.Test/TestGrain.cs
+++ b/test/Orleans.Http.Test/TestGrain.cs
@@ -71,8 +71,11 @@ namespace Orleans.Http.Test
         [HttpPost("{grainId}/SameUrlAndMethod")]
         Task SameUrlAndMethod();
 
-        [HttpGet(pattern: "Get", routeGrainProvider: typeof(RandomGuidRouteGrainProvider))]
-        Task Get5();
+        [HttpGet(pattern: "Get6", routeGrainProvider: typeof(RandomGuidRouteGrainProvider))]
+        Task Get6();
+
+        [HttpGet(pattern: "Get7", routeGrainProvider: typeof(FailingRouteGrainProvider))]
+        Task Get7();
     }
 
     [ProtoContract]
@@ -175,7 +178,9 @@ namespace Orleans.Http.Test
 
         public Task SameUrlAndMethod() => Task.CompletedTask;
 
-        public Task Get5() => Task.CompletedTask;
+        public Task Get6() => Task.CompletedTask;
+
+        public Task Get7() => Task.CompletedTask;
     }
 
     public class RandomGuidRouteGrainProvider : IRouteGrainProvider
@@ -190,6 +195,14 @@ namespace Orleans.Http.Test
         public Task<IGrain> GetGrain(Type grainType)
         {
             return Task.FromResult(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
+        }
+    }
+
+    public class FailingRouteGrainProvider : IRouteGrainProvider
+    {
+        public Task<IGrain> GetGrain(Type grainType)
+        {
+            return Task.FromResult<IGrain>(null);
         }
     }
 }

--- a/test/Orleans.Http.Test/TestGrain.cs
+++ b/test/Orleans.Http.Test/TestGrain.cs
@@ -71,10 +71,10 @@ namespace Orleans.Http.Test
         [HttpPost("{grainId}/SameUrlAndMethod")]
         Task SameUrlAndMethod();
 
-        [HttpGet(pattern: "Get6", routeGrainProvider: typeof(RandomGuidRouteGrainProvider))]
+        [HttpGet(pattern: "Get6", routeGrainProviderPolicy: nameof(RandomGuidRouteGrainProvider))]
         Task Get6();
 
-        [HttpGet(pattern: "Get7", routeGrainProvider: typeof(FailingRouteGrainProvider))]
+        [HttpGet(pattern: "Get7", routeGrainProviderPolicy: nameof(FailingRouteGrainProvider))]
         Task Get7();
 
         [HttpGet(pattern: "Get8")]

--- a/test/Orleans.Http.Test/TestGrain.cs
+++ b/test/Orleans.Http.Test/TestGrain.cs
@@ -192,17 +192,18 @@ namespace Orleans.Http.Test
             _cluserClient = clusterClient;
         }
 
-        public Task<IGrain> GetGrain(Type grainType)
+        public ValueTask<IGrain> GetGrain(Type grainType)
         {
-            return Task.FromResult(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
+            return new ValueTask<IGrain>(_cluserClient.GetGrain(grainType, Guid.NewGuid()));
         }
     }
 
     public class FailingRouteGrainProvider : IRouteGrainProvider
     {
-        public Task<IGrain> GetGrain(Type grainType)
+        public ValueTask<IGrain> GetGrain(Type grainType)
         {
-            return Task.FromResult<IGrain>(null);
+            IGrain nullResult = null;
+            return new ValueTask<IGrain>(nullResult);
         }
     }
 }

--- a/test/Orleans.Http.Test/TestGrain.cs
+++ b/test/Orleans.Http.Test/TestGrain.cs
@@ -76,6 +76,9 @@ namespace Orleans.Http.Test
 
         [HttpGet(pattern: "Get7", routeGrainProvider: typeof(FailingRouteGrainProvider))]
         Task Get7();
+
+        [HttpGet(pattern: "Get8")]
+        Task Get8();
     }
 
     [ProtoContract]
@@ -181,6 +184,8 @@ namespace Orleans.Http.Test
         public Task Get6() => Task.CompletedTask;
 
         public Task Get7() => Task.CompletedTask;
+
+        public Task Get8() => Task.CompletedTask;
     }
 
     public class RandomGuidRouteGrainProvider : IRouteGrainProvider


### PR DESCRIPTION
This allows the usage of Orleans.Http without route constraints. Implementors may create classes that return the wanted IGrain from any information they may need, and have access to everything in the project through dependency injection. I added in the example usage of one that just provided a new GUID as the grain id. This will allow the server to be explicit in what grains are accessed and not give that control to the api consumers if that is what is wanted. Specifying a route grain provider is optional and it will default to the current behaviour. Let me know what y'all think, or any requested changes. 